### PR TITLE
Updated license information in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "javascript"
   ],
   "author": "kyldvs",
-  "license": "ISC",
+  "license": "MIT",
   "bugs": {
     "url": "https://github.com/kyldvs/ast-types-flow/issues"
   },


### PR DESCRIPTION
Updated license information to MIT in package.json to match LICENSE file.

This PR should maybe be merged/released together with #2.